### PR TITLE
Removing darwin/386/1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Compile
         uses: xxxserxxx/actions/golang-build@master
         with:
-          args: darwin/amd64/1 darwin/386/1 linux/amd64 linux/386 linux/arm64 linux/arm7 linux/arm6 linux/arm5 windows/amd64 windows/386 freebsd/amd64 freebsd/386
+          args: darwin/amd64/1 linux/amd64 linux/386 linux/arm64 linux/arm7 linux/arm6 linux/arm5 windows/amd64 windows/386 freebsd/amd64 freebsd/386

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > - **Fixed**: for any bug fixes.
 > - **Security**: in case of vulnerabilities.
 
-## [3.4.3] - ??
+## [3.4.4] - ??
 
 ### Added
 

--- a/cmd/gotop/main.go
+++ b/cmd/gotop/main.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	appName = "gotop"
-	version = "3.4.3"
+	version = "3.4.4"
 
 	graphHorizontalScaleDelta = 3
 	defaultUI                 = "cpu\ndisk/1 2:mem/2\ntemp\nnet procs"


### PR DESCRIPTION
Is there a need to bother building for 386? If memory serves, Apple has even dropped 32-bit support.

Honestly not sure how much time it saves on builds, but figured it's best to trim out what's not really needed. 😅