### PR TITLE
Fix crash when loading a custom colorscheme

### DIFF
--- a/colorschemes/registry.go
+++ b/colorschemes/registry.go
@@ -18,14 +18,11 @@ func init() {
 }
 
 func FromName(confDir configdir.ConfigDir, c string) (Colorscheme, error) {
-	cs, ok := registry[c]
-	if !ok {
-		cs, err := getCustomColorscheme(confDir, c)
-		if err != nil {
-			return cs, err
-		}
+	if cs, ok := registry[c]; ok {
+		return cs, nil
 	}
-	return cs, nil
+	cs, err := getCustomColorscheme(confDir, c)
+	return cs, err
 }
 
 func register(name string, c Colorscheme) {


### PR DESCRIPTION
When using `cs, err := ...` in a nested scope, it masks `cs` and `err`
from any parent scope.

----

I see this bug so often in my own code, it's a wonder that some static analysis doesn't find it. I'm not super familiar with Go development, though, so maybe I just don't know how to run `go vet` :P