### PR TITLE
Use dup2 on FreeBSD aarch64

### DIFF
--- a/logging/logging_arm64.go
+++ b/logging/logging_arm64.go
@@ -1,4 +1,4 @@
-// +build arm64
+// +build linux,arm64
 
 package logging
 

--- a/logging/logging_other.go
+++ b/logging/logging_other.go
@@ -1,5 +1,5 @@
 // +build linux openbsd freebsd darwin
-// +build !arm64
+// +build !linux,arm64
 
 package logging
 


### PR DESCRIPTION
Hi,

I have the following errors on FreeBSD aarch64 :
logging/logging_arm64.go:11:2: undefined: syscall.Dup3

Is it possible to bump gopsutil version? It's a bit old and doesn't have the FreeBSD aarch64 bits:
```
# github.com/shirou/gopsutil/cpu
vendor/github.com/shirou/gopsutil/cpu/cpu_freebsd.go:25:16: undefined: cpuTimes
vendor/github.com/shirou/gopsutil/cpu/cpu_freebsd.go:42:31: undefined: cpuTimes
vendor/github.com/shirou/gopsutil/cpu/cpu_freebsd.go:66:38: undefined: cpuTimes
vendor/github.com/shirou/gopsutil/cpu/cpu_freebsd.go:72:15: undefined: cpuTimes
vendor/github.com/shirou/gopsutil/cpu/cpu_freebsd.go:87:13: undefined: cpuTimes
# github.com/shirou/gopsutil/disk
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:26:36: undefined: MNT_WAIT
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:31:15: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:32:28: undefined: MNT_WAIT
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:38:17: undefined: MNT_RDONLY
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:41:17: undefined: MNT_SYNCHRONOUS
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:44:17: undefined: MNT_NOEXEC
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:154:9: undefined: Bintime
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:163:22: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:167:54: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:182:32: undefined: Devstat
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:44:17: too many errors
```

Thanks!