### PR TITLE
Align CPU values in CPU widget

### DIFF
--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -120,7 +120,7 @@ func (cpu *CPUWidget) update() {
 			defer cpu.updateLock.Unlock()
 			for key, percent := range cpus {
 				cpu.Data[key] = append(cpu.Data[key], float64(percent))
-				cpu.Labels[key] = fmt.Sprintf("%d%%", percent)
+				cpu.Labels[key] = fmt.Sprintf("%3d%%", percent)
 				cpu.cpuLoads[key] = float64(percent)
 			}
 		}()


### PR DESCRIPTION
The misalignment of the average CPU value in the CPU widget makes the display format no longer uniform. So I think it may need to be improved.

![F87C1D22-3380-40D3-9986-01B756BE2ED5](https://user-images.githubusercontent.com/5037285/88047144-bd947980-cb83-11ea-8c2a-561287d59981.jpeg)