### PR TITLE
[docs] Fix links in docs

### DIFF
--- a/docs/colorschemes.md
+++ b/docs/colorschemes.md
@@ -1,8 +1,8 @@
 # Colorschemes
 
-gotop ships with a few colorschemes which can be set with the `-c` flag followed by the name of one. You can find all the colorschemes in the [colorschemes folder](./colorschemes).
+gotop ships with a few colorschemes which can be set with the `-c` flag followed by the name of one. You can find all the colorschemes in the [colorschemes folder](../colorschemes).
 
-To make a custom colorscheme, check out the [template](./colorschemes/template.go) for instructions and then use [default.json](./colorschemes/default.json) as a starter. Then put the file at `~/.config/gotop/<name>.json` and load it with `gotop -c <name>`. Colorschemes PR's are welcome!
+To make a custom colorscheme, check out the [template](../colorschemes/template.go) for instructions and then use [default.json](../colorschemes/default.json) as a starter. Then put the file at `~/.config/gotop/<name>.json` and load it with `gotop -c <name>`. Colorschemes PR's are welcome!
 
 To list all built-in color schemes, call:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,7 +8,7 @@
 6. Download and verify the correct version of one of the binaries
 7. Finish the draft release and publish.
 8. Check gotop-builder for a successful everything build; if successful, publish.
-10. Wait for the [AUR](https://github.com/xxxserxxx/gotop-linux] project to finish building.
+10. Wait for the [AUR](https://github.com/xxxserxxx/gotop-linux) project to finish building.
     1. update arch (gotop-linux) and run `aurpublish gotop` and `aurpublish gotop-bin`
     2. Test install `gotop` and `gotop-bin` with running & version check
 11. Notify Nix


### PR DESCRIPTION
- 3 Links in colorschemes.md lead to the current docs directory instead of its actual directory in the root

- 1 link in releasing.md didnt have the correct linking syntax causing the link to send the user to a page that doesnt exist