### PR TITLE
logging: Use dup(2) syscall on darwin

### DIFF
--- a/logging/logging_arm64.go
+++ b/logging/logging_arm64.go
@@ -1,4 +1,4 @@
-// +build !freebsd,arm64
+// +build !freebsd,!darwin,arm64
 
 package logging
 

--- a/logging/logging_other.go
+++ b/logging/logging_other.go
@@ -1,9 +1,11 @@
-// +build linux,!arm64 openbsd,!arm64 freebsd darwin,!arm64
+// +build linux,!arm64 openbsd,!arm64 freebsd darwin
 
 package logging
 
-import "syscall"
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
 func stderrToLogfile(logfile *os.File) {
 	syscall.Dup2(int(logfile.Fd()), 2)


### PR DESCRIPTION
I'd still like to test that this doesn't bork builds on Intel-based Macbooks.