### PR TITLE
Add support for building on Apple Silicon

### DIFF
--- a/logging/logging_arm64.go
+++ b/logging/logging_arm64.go
@@ -1,4 +1,4 @@
-// +build !freebsd,arm64
+// +build !freebsd,arm64, !darwin
 
 package logging
 

--- a/logging/logging_other.go
+++ b/logging/logging_other.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64 openbsd,!arm64 freebsd darwin,!arm64
+// +build linux,!arm64 openbsd,!arm64 freebsd darwin
 
 package logging
 


### PR DESCRIPTION
Don't build logging_arm64 when on darwin, MacOS on arm64 does not have a dup3 syscall
Remove \!arm64 from logging_other, so builds work on MacOS on arm64 (Apple Silicon)