### PR TITLE
Fix translation of "free"

### DIFF
--- a/translations/dicts/eo.toml
+++ b/translations/dicts/eo.toml
@@ -157,7 +157,7 @@ negvalsent="28| eraro: negativa valoro por ĵus senditaj retdatumoj de gopsutil.
 disk="Disko"
 mount="Monto"
 used="Uzita"
-free="Senpaga"
+free="Libera"
 rs="R/s"
 ws="W/s"
 


### PR DESCRIPTION
"Senpaga" literally means "no payment [necessary]," so it refers to "free" only in the sense of "free beer." But here we want to evoke remaining disk space.