### PR TITLE
logging: add support for riscv64

### DIFF
--- a/logging/logging_other.go
+++ b/logging/logging_other.go
@@ -1,4 +1,5 @@
 // +build linux,!arm64 openbsd,!arm64 freebsd darwin,!arm64
+// +build linux,!riscv64 openbsd,!riscv64 freebsd darwin,!riscv64
 
 package logging
 

--- a/logging/logging_riscv64.go
+++ b/logging/logging_riscv64.go
@@ -1,0 +1,12 @@
+// +build !freebsd,riscv64
+
+package logging
+
+import (
+	"os"
+	"syscall"
+)
+
+func stderrToLogfile(logfile *os.File) {
+	syscall.Dup3(int(logfile.Fd()), 2, 0)
+}


### PR DESCRIPTION
It looks like syscall.Dup2 is not supported on riscv64 similar as aarch64.
I'm not an golang coder so if this needs some love please educate me. 

ref: https://github.com/alpinelinux/aports/commit/52825ccc02feefe12ce2d747f02520b1f65848f9

```logging/logging_other.go:9:2: undefined: syscall.Dup2```