### PR TITLE
Fix build failure on riscv64 caused by missing syscall

### DIFF
--- a/logging/logging_dup2.go
+++ b/logging/logging_dup2.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64 openbsd,!arm64 freebsd darwin
+// +build linux,!arm64,!riscv64 openbsd,!arm64 freebsd darwin
 
 package logging
 

--- a/logging/logging_dup3.go
+++ b/logging/logging_dup3.go
@@ -1,4 +1,4 @@
-// +build !freebsd,!darwin,arm64
+// +build !freebsd,!darwin,arm64 linux,riscv64
 
 package logging
 


### PR DESCRIPTION
Hello. This is Camber from Anthon community and I am working on maintaining go-based packages in our distro's repository including gotop. I encountered a build failure on our riscv64 target and managed to write a patch for the issue.

On RISC-V 64-bit linux systems, syscall `dup2()` is not available, therefore `syscall.Dup2` will become undefined and gotop will fail to be built from source. This patch updates building target of logging/logging_{other,arm64} and renames them based on syscall used.

I can personally confirm that the patch will solve aforementioned issue. 

Reference: 
- https://github.com/AOSC-Dev/aosc-os-abbs/pull/3923#issuecomment-1120590282
- https://github.com/AOSC-Dev/aosc-os-abbs/pull/3923/commits/0a71c63df0b405818070e4615b0b306270c64108
- https://github.com/AOSC-Dev/aosc-os-abbs/pull/3923/commits/ca7dfe94787a551e26e3c454e530ea9da0dc543b