### PR TITLE
Add scoop installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you install gotop by hand, or you download or create new layouts or colorsche
     sudo emerge gotop
     ```
 - **OSX**: gotop is in *homebrew-core*.  `brew install gotop`.  Make sure to uninstall and untap any previous installations or taps.
+- **Windows**: gotop is in the [Main](https://github.com/ScoopInstaller/Main) bucket. `scoop install gotop`.
 - **Prebuilt binaries**: Binaries for most systems can be downloaded from [the github releases page](https://github.com/xxxserxxx/gotop/releases). RPM and DEB packages are also provided.
 - **Source**: This requires Go >= 1.16. `go install github.com/xxxserxxx/gotop/v4/cmd/gotop@latest`
 


### PR DESCRIPTION
gotop is available in Scoop for Windows.