### PR TITLE
WIP: Add CPU/Mem Pressure Stall Information on Linux

### DIFF
--- a/devices/mem.go
+++ b/devices/mem.go
@@ -10,6 +10,7 @@ type MemoryInfo struct {
 	Total       uint64
 	Used        uint64
 	UsedPercent float64
+	Pressure    float64
 }
 
 func RegisterMem(f func(map[string]MemoryInfo) map[string]error) {

--- a/devices/mem_mem.go
+++ b/devices/mem_mem.go
@@ -18,9 +18,7 @@ func init() {
 			Total:       mainMemory.Total,
 			Used:        mainMemory.Used,
 			UsedPercent: mainMemory.UsedPercent,
-		}
-		mems["Pressure"] = MemoryInfo{
-			Pressure: pressure.SomeAvg10,
+			Pressure:    pressure.SomeAvg10,
 		}
 		return nil
 	}

--- a/devices/mem_mem.go
+++ b/devices/mem_mem.go
@@ -10,10 +10,17 @@ func init() {
 		if err != nil {
 			return map[string]error{"Main": err}
 		}
+		pressure, err := psMem.Pressure()
+		if err != nil {
+			return map[string]error{"Pressure": err}
+		}
 		mems["Main"] = MemoryInfo{
 			Total:       mainMemory.Total,
 			Used:        mainMemory.Used,
 			UsedPercent: mainMemory.UsedPercent,
+		}
+		mems["Pressure"] = MemoryInfo{
+			Pressure: pressure.SomeAvg10,
 		}
 		return nil
 	}

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -21,6 +21,7 @@ type CPUWidget struct {
 	updateInterval  time.Duration
 	cpuLoads        map[string]float64
 	average         ewma.MovingAverage
+	pressure        float64
 }
 
 var cpuLabels []string
@@ -38,6 +39,8 @@ func NewCPUWidget(updateInterval time.Duration, horizontalScale int, showAverage
 	self.LabelStyles[AVRG] = termui.ModifierBold
 	self.Title = tr.Value("widget.label.cpu")
 	self.HorizontalScale = horizontalScale
+	cpuPressure, _ := cpu.Pressure()
+	self.pressure = cpuPressure.SomeAvg10
 
 	if !(self.ShowAverageLoad || self.ShowPerCPULoad) {
 		if self.CPUCount <= 8 {
@@ -114,7 +117,7 @@ func (cpu *CPUWidget) update() {
 			cpu.average.Add(float64(sum) / float64(len(cpus)))
 			avg := cpu.average.Value()
 			cpu.Data[AVRG] = append(cpu.Data[AVRG], avg)
-			cpu.Labels[AVRG] = fmt.Sprintf("%3.0f%%", avg)
+			cpu.Labels[AVRG] = fmt.Sprintf("%3.0f%% %3.0f%%", avg, cpu.pressure)
 			cpu.cpuLoads[AVRG] = avg
 		}
 	}()

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/VividCortex/ewma"
+	gopsutilCPU "github.com/shirou/gopsutil/v3/cpu"
 	"github.com/xxxserxxx/gotop/v4/devices"
 
 	"github.com/gizak/termui/v3"
@@ -39,7 +40,7 @@ func NewCPUWidget(updateInterval time.Duration, horizontalScale int, showAverage
 	self.LabelStyles[AVRG] = termui.ModifierBold
 	self.Title = tr.Value("widget.label.cpu")
 	self.HorizontalScale = horizontalScale
-	cpuPressure, _ := cpu.Pressure()
+	cpuPressure, _ := gopsutilCPU.Pressure()
 	self.pressure = cpuPressure.SomeAvg10
 
 	if !(self.ShowAverageLoad || self.ShowPerCPULoad) {
@@ -116,8 +117,9 @@ func (cpu *CPUWidget) update() {
 		if cpu.ShowAverageLoad {
 			cpu.average.Add(float64(sum) / float64(len(cpus)))
 			avg := cpu.average.Value()
+			pressure, _ := gopsutilCPU.Pressure()
 			cpu.Data[AVRG] = append(cpu.Data[AVRG], avg)
-			cpu.Labels[AVRG] = fmt.Sprintf("%3.0f%% %3.0f%%", avg, cpu.pressure)
+			cpu.Labels[AVRG] = fmt.Sprintf("%3.0f%% %3.0f%%", avg, pressure.SomeAvg10)
 			cpu.cpuLoads[AVRG] = avg
 		}
 	}()

--- a/widgets/mem.go
+++ b/widgets/mem.go
@@ -70,8 +70,9 @@ func (mem *MemWidget) renderMemInfo(line string, memoryInfo devices.MemoryInfo) 
 	mem.Data[line] = append(mem.Data[line], memoryInfo.UsedPercent)
 	memoryTotalBytes, memoryTotalMagnitude := utils.ConvertBytes(memoryInfo.Total)
 	memoryUsedBytes, memoryUsedMagnitude := utils.ConvertBytes(memoryInfo.Used)
-	mem.Labels[line] = fmt.Sprintf("%3.0f%% %5.1f%s/%.0f%s",
+	mem.Labels[line] = fmt.Sprintf("%3.0f%% %3.0f%% %5.1f%s/%.0f%s",
 		memoryInfo.UsedPercent,
+		memoryInfo.Pressure,
 		memoryUsedBytes,
 		memoryUsedMagnitude,
 		memoryTotalBytes,


### PR DESCRIPTION
if https://github.com/shirou/gopsutil/pull/1457 gets merged and gotop updates the goputils lib version to the latest one, this PR would add CPU/Mem Pressure Stall Information (https://facebookmicrosites.github.io/psi/docs/overview) percentage for CPU and Memory on linux