### PR TITLE
Fix build failure on loongarch64 due to missed syscall

### DIFF
--- a/logging/logging_dup2.go
+++ b/logging/logging_dup2.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64,!riscv64 openbsd,!arm64 freebsd darwin
+// +build linux,!arm64,!loong64,!riscv64 openbsd,!arm64 freebsd darwin
 
 package logging
 

--- a/logging/logging_dup3.go
+++ b/logging/logging_dup3.go
@@ -1,4 +1,4 @@
-// +build !freebsd,!darwin,arm64 linux,riscv64
+// +build !freebsd,!darwin,arm64 linux,loong64 linux,riscv64
 
 package logging
 


### PR DESCRIPTION
Just as riscv64, loongarch64 does not have dup2 syscall, so we have to adjust the build system instructions accordingly.