### PR TITLE
Add support for NetBSD.

### DIFF
--- a/logging/logging_dup2.go
+++ b/logging/logging_dup2.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64,!riscv64 openbsd,!arm64 freebsd darwin
+// +build linux,!arm64,!riscv64 openbsd,!arm64 freebsd darwin netbsd
 
 package logging
 

--- a/widgets/proc_netbsd.go
+++ b/widgets/proc_netbsd.go
@@ -1,0 +1,73 @@
+// +build netbsd
+
+package widgets
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/xxxserxxx/gotop/v4/utils"
+)
+
+const (
+	// Define column widths for ps output used in Procs()
+	five  = "12345"
+	ten   = five + five
+	fifty = ten + ten + ten + ten + ten
+)
+
+func getProcs() ([]Proc, error) {
+	// NetBSD ps does not support comma-separated keywords in a single -o argument:
+	// it treats everything after the first '=' as the column header, so commas are
+	// included in the header rather than parsed as keyword separators.
+	// Use separate -o flags instead to get all five columns.
+	//
+	// Column layout with these headers (0-indexed):
+	//   [0:10]   pid  (10 chars, right-justified)
+	//   [11:61]  comm (50 chars, left-justified)
+	//   [62:67]  pcpu (5 chars, right-justified)
+	//   [68:73]  pmem (5 chars, right-justified)
+	//   [74:]    args
+	output, err := exec.Command("ps", "-caxo", "pid="+ten,
+		"-o", "comm="+fifty,
+		"-o", "pcpu="+five,
+		"-o", "pmem="+five,
+		"-o", "args").Output()
+	if err != nil {
+		return nil, fmt.Errorf("%s", tr.Value("widget.proc.err.ps", err.Error()))
+	}
+
+	// converts to []string and removes the header
+	linesOfProcStrings := strings.Split(strings.TrimSpace(string(output)), "\n")[1:]
+	procs := []Proc{}
+	for _, line := range linesOfProcStrings {
+		if len(line) < 74 {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(line[0:10]))
+		if err != nil {
+			log.Println(tr.Value("widget.proc.err.pidconv", err.Error(), line))
+		}
+		cpu, err := strconv.ParseFloat(utils.ConvertLocalizedString(strings.TrimSpace(line[62:67])), 64)
+		if err != nil {
+			log.Println(tr.Value("widget.proc.err.cpuconv", err.Error(), line))
+		}
+		mem, err := strconv.ParseFloat(utils.ConvertLocalizedString(strings.TrimSpace(line[68:73])), 64)
+		if err != nil {
+			log.Println(tr.Value("widget.proc.err.memconv", err.Error(), line))
+		}
+		proc := Proc{
+			Pid:         pid,
+			CommandName: strings.TrimSpace(line[11:61]),
+			CPU:         cpu,
+			Mem:         mem,
+			FullCommand: strings.TrimSpace(line[74:]),
+		}
+		procs = append(procs, proc)
+	}
+
+	return procs, nil
+}


### PR DESCRIPTION
This is the follow up to #274 introducing NetBSD support.

This pull request adds NetBSD support to the project by updating build constraints and introducing a new implementation for process listing on NetBSD. The most significant changes are:

**NetBSD Support**

* Added a new file `widgets/proc_netbsd.go` that implements the `getProcs()` function using NetBSD-specific `ps` command syntax and output parsing to retrieve process information. This includes careful handling of column widths and conversion of process data.
* Support for _Temperature is sensors is currently missing_ in NetBSD (since I need to run it on actual h/w to check if it works). I do plan on adding support to it, once I have time to debug it. 

**Build Constraints**

* Updated the build tag in `logging/logging_dup2.go` to include `netbsd`, ensuring the file is included in NetBSD builds.

**Screenshot**

<img width="1381" height="657" alt="image" src="https://github.com/user-attachments/assets/7fe66782-0a0b-403b-a071-246eaa5ac553" />

Running in NetBSD 10.1.

> P.S: Some of the code has been written using AI Agent assistance. 
